### PR TITLE
Revert to ruby 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest AS config-builder
+FROM ruby:2.7.5 AS config-builder
 
 RUN mkdir /workspace/
 WORKDIR /workspace/


### PR DESCRIPTION
Ruby 3 has a problem with the yaml parser with aliases
error was
in `visit_Psych_Nodes_Alias': Unknown alias: XXX (Psych::BadAlias)